### PR TITLE
Configuration options for prover/coordinator

### DIFF
--- a/common/src/prover.rs
+++ b/common/src/prover.rs
@@ -60,6 +60,9 @@ pub struct ProofRequestOptions {
     /// Additionaly aggregates the circuit proof if true
     #[serde(default = "default_bool")]
     pub aggregate: bool,
+    /// Runs the MockProver if proofing fails.
+    #[serde(default = "default_bool")]
+    pub mock_feedback: bool,
 }
 
 impl PartialEq for ProofRequestOptions {

--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -325,6 +325,10 @@ async fn handle_method(
 ) -> Result<serde_json::Value, String> {
     match method {
         "config" => {
+            if !shared_state.config.lock().await.unsafe_rpc {
+                return Err("this method is disabled".to_string());
+            }
+
             let config = match params.get(0) {
                 Some(options) => {
                     let options: Config =

--- a/coordinator/src/bin/coordinator.rs
+++ b/coordinator/src/bin/coordinator.rs
@@ -266,7 +266,8 @@ async fn handle_request(
 /// Discovers healthy nodes via DNS service discovery.
 /// If nodes are discovered but are not up-to-date, then this function attempts to choose a
 /// fallback node.
-async fn check_nodes(ctx: SharedState, server_nodes: String, client: hyper::Client<HttpConnector>) {
+async fn check_nodes(ctx: SharedState, client: hyper::Client<HttpConnector>) {
+    let server_nodes = ctx.config.lock().await.rpc_server_nodes.clone();
     let head_hash = ctx.rw.lock().await.chain_state.head_block_hash;
     let mut nodes = Vec::new();
     let mut fallback_node_uri = None;
@@ -324,23 +325,19 @@ async fn handle_method(
 ) -> Result<serde_json::Value, String> {
     match method {
         "config" => {
-            #[derive(serde::Deserialize)]
-            struct CoordinatorConfig {
-                dummy_proof: bool,
-            }
+            let config = match params.get(0) {
+                Some(options) => {
+                    let options: Config =
+                        serde_json::from_value(options.to_owned()).map_err(|e| e.to_string())?;
 
-            let options = params.get(0).ok_or("expected struct CoordinatorConfig")?;
-            let options: CoordinatorConfig =
-                serde_json::from_value(options.to_owned()).map_err(|e| e.to_string())?;
+                    shared_state.set_config(options.clone()).await;
+                    options
+                }
+                None => shared_state.get_config().await,
+            };
 
-            shared_state.config.lock().await.dummy_prover = options.dummy_proof;
-
-            Ok(serde_json::Value::Bool(true))
-        }
-
-        "get_config" => {
-            // TODO: possible to do it without to_owned?
-            Ok(serde_json::to_value(shared_state.get_config_owned().await).unwrap())
+            // return the current configuration
+            Ok(serde_json::to_value(config).unwrap())
         }
 
         _ => Err("this method is not available".to_string()),
@@ -431,12 +428,7 @@ async fn main() {
             let client = hyper::Client::new();
             loop {
                 log::debug!("spawning check_nodes task");
-                let res = spawn(check_nodes(
-                    ctx.clone(),
-                    config.rpc_server_nodes.clone(),
-                    client.to_owned(),
-                ))
-                .await;
+                let res = spawn(check_nodes(ctx.clone(), client.to_owned())).await;
 
                 if let Err(err) = res {
                     log::error!("task: {}", err);

--- a/coordinator/src/config.rs
+++ b/coordinator/src/config.rs
@@ -69,6 +69,10 @@ pub struct Config {
     #[clap(long, env = "COORDINATOR_AGGREGATE_PROOF", default_value_t = false)]
     /// Signals the prover to aggregate the circuit proof
     pub aggregate_proof: bool,
+
+    #[clap(long, env = "COORDINATOR_UNSAFE_RPC", default_value_t = false)]
+    /// Allow unsafe rpc methods of the coordinator if true
+    pub unsafe_rpc: bool,
 }
 
 impl Config {

--- a/coordinator/src/config.rs
+++ b/coordinator/src/config.rs
@@ -1,12 +1,12 @@
 use clap::Parser;
 use ethers_core::types::Address;
 use hyper::Uri;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use std::net::SocketAddr;
 
 #[serde_as]
-#[derive(Parser, Serialize, Clone, Debug)]
+#[derive(Parser, Deserialize, Serialize, Clone, Debug)]
 #[clap(version, about)]
 /// zkEVM coordinator, coordinates between the prover and the block production and relays between the bridge contracts in L1 and L2.
 pub struct Config {
@@ -29,6 +29,10 @@ pub struct Config {
     #[clap(long, env = "COORDINATOR_MOCK_PROVER", default_value_t = false)]
     /// Only use the mock prover for proof requests.
     pub mock_prover: bool,
+
+    #[clap(long, env = "COORDINATOR_MOCK_PROVER_IF_ERROR", default_value_t = true)]
+    /// Run the mock prover if a proof request fails.
+    pub mock_prover_if_error: bool,
 
     #[clap(long, env = "COORDINATOR_L1_RPC_URL")]
     #[serde_as(as = "DisplayFromStr")]

--- a/coordinator/src/shared_state.rs
+++ b/coordinator/src/shared_state.rs
@@ -1026,6 +1026,7 @@ impl SharedState {
             param: config.params_path.clone(),
             mock: config.mock_prover,
             aggregate: config.aggregate_proof,
+            mock_feedback: true,
         };
         drop(config);
 

--- a/coordinator/src/shared_state.rs
+++ b/coordinator/src/shared_state.rs
@@ -1026,7 +1026,7 @@ impl SharedState {
             param: config.params_path.clone(),
             mock: config.mock_prover,
             aggregate: config.aggregate_proof,
-            mock_feedback: true,
+            mock_feedback: config.mock_prover_if_error,
         };
         drop(config);
 
@@ -1053,8 +1053,16 @@ impl SharedState {
         }
     }
 
-    pub async fn get_config_owned(&self) -> Config {
+    /// Returns the current coordinator configuration.
+    pub async fn get_config(&self) -> Config {
         self.config.lock().await.to_owned()
+    }
+
+    /// Sets the coordinator configuration.
+    /// Not all changes to the config may be reflected.
+    pub async fn set_config(&self, config: Config) {
+        // TODO: doesn't update all config values at the moment.
+        *self.config.lock().await = config;
     }
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,6 +131,7 @@ services:
       - COORDINATOR_ENABLE_FAUCET=true
       - COORDINATOR_PARAMS_PATH=${PARAMS_PATH:-/testnet/}
       - COORDINATOR_CIRCUIT_NAME=super
+      - COORDINATOR_UNSAFE_RPC=${COORDINATOR_UNSAFE_RPC:-false}
 
   prover-rpcd:
     init: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -174,6 +174,7 @@ services:
       - COORDINATOR_PROVER_RPCD_URL=http://dev:8001
       - PROVERD_BIND=[::]:8001
       - COORDINATOR_CIRCUIT_NAME=pi
+      - COORDINATOR_UNSAFE_RPC=true
     ports:
       - 8000:8000
     working_dir: /app

--- a/prover/src/bin/prover_cmd.rs
+++ b/prover/src/bin/prover_cmd.rs
@@ -34,6 +34,7 @@ async fn main() {
         param: params_path,
         mock: false,
         aggregate: false,
+        ..Default::default()
     };
 
     state.get_or_enqueue(&request).await;

--- a/prover/src/shared_state.rs
+++ b/prover/src/shared_state.rs
@@ -115,7 +115,12 @@ macro_rules! gen_proof {
                     PoseidonTranscript<NativeLoader, _, _>,
                     _,
                 >(
-                    &param, &pk, circuit, circuit_instance.clone(), fixed_rng()
+                    &param,
+                    &pk,
+                    circuit,
+                    circuit_instance.clone(),
+                    fixed_rng(),
+                    task_options.mock_feedback,
                 );
                 circuit_proof.duration =
                     Instant::now().duration_since(time_started).as_millis() as u32;
@@ -161,6 +166,7 @@ macro_rules! gen_proof {
                     agg_circuit,
                     agg_instance,
                     fixed_rng(),
+                    task_options.mock_feedback,
                 );
                 aggregation_proof.duration =
                     Instant::now().duration_since(time_started).as_millis() as u32;
@@ -174,7 +180,12 @@ macro_rules! gen_proof {
                     EvmTranscript<G1Affine, _, _, _>,
                     _,
                 >(
-                    &param, &pk, circuit, circuit_instance.clone(), fixed_rng()
+                    &param,
+                    &pk,
+                    circuit,
+                    circuit_instance.clone(),
+                    fixed_rng(),
+                    task_options.mock_feedback,
                 );
                 circuit_proof.duration =
                     Instant::now().duration_since(time_started).as_millis() as u32;

--- a/prover/src/utils.rs
+++ b/prover/src/utils.rs
@@ -39,6 +39,7 @@ pub fn gen_proof<
     circuit: C,
     instance: Vec<Vec<Fr>>,
     rng: RNG,
+    mock_feedback: bool,
 ) -> Vec<u8> {
     let mut transcript = TW::init(Vec::new());
     let inputs: Vec<&[Fr]> = instance.iter().map(|v| v.as_slice()).collect();
@@ -52,10 +53,14 @@ pub fn gen_proof<
     );
     // run the `MockProver` and return (hopefully) useful errors
     if let Err(proof_err) = res {
-        let res = MockProver::run(params.k(), &circuit, instance)
-            .expect("MockProver::run")
-            .verify_par();
-        panic!("gen_proof: {:#?}\nMockProver: {:#?}", proof_err, res);
+        if mock_feedback {
+            let res = MockProver::run(params.k(), &circuit, instance)
+                .expect("MockProver::run")
+                .verify_par();
+            panic!("gen_proof: {:#?}\nMockProver: {:#?}", proof_err, res);
+        } else {
+            panic!("gen_proof: {:#?}", proof_err);
+        }
     }
 
     transcript.finalize()

--- a/prover/tests/proverd.rs
+++ b/prover/tests/proverd.rs
@@ -30,8 +30,7 @@ async fn proverd_simple_signaling() {
         param: "/none".to_string(),
         retry: false,
         rpc: "http://localhost:1111".to_string(),
-        mock: false,
-        aggregate: false,
+        ..Default::default()
     };
     let proof_b = ProofRequestOptions {
         circuit: "super".to_string(),
@@ -39,8 +38,7 @@ async fn proverd_simple_signaling() {
         param: "/none".to_string(),
         retry: false,
         rpc: "http://localhost:1111".to_string(),
-        mock: false,
-        aggregate: false,
+        ..Default::default()
     };
 
     // enqueue tasks

--- a/prover/tests/verifier.rs
+++ b/prover/tests/verifier.rs
@@ -163,6 +163,7 @@ macro_rules! test_aggregation {
                             circuit.clone(),
                             circuit.instance(),
                             fixed_rng(),
+                            true,
                         );
                         data.instance = collect_instance(&circuit.instance());
                         data.proof = proof.into();
@@ -178,7 +179,7 @@ macro_rules! test_aggregation {
                         PoseidonTranscript<NativeLoader, _, _>,
                         _,
                     >(
-                        &params, &pk, circuit, instance.clone(), fixed_rng()
+                        &params, &pk, circuit, instance.clone(), fixed_rng(), true
                     );
 
                     let protocol = compile(
@@ -214,6 +215,7 @@ macro_rules! test_aggregation {
                     agg_circuit.clone(),
                     agg_circuit.instance(),
                     fixed_rng(),
+                    true,
                 );
                 data.instance = collect_instance(&agg_circuit.instance());
                 data.proof = proof.into();


### PR DESCRIPTION
Add the following features:
###### coordinator
- `unsafe_rpc` option for the coordinator. To guard methods like `config`
- `mock_prover_if_error` option. Defaults to true and runs the mock prover if the real prover fails.
- Add uniform `config` rpc method to get/set the coordinator configuration.
  Not all config options are being reflected yet.
###### prover
- Add `mock_feedback` to `ProofRequestOptions. If true, runs the MockProver if proofing fails.

Fixes: #80
Related: #58 