### PR TITLE
hack around geth `eth_getLogs` inconsistency

### DIFF
--- a/coordinator/src/shared_state.rs
+++ b/coordinator/src/shared_state.rs
@@ -185,6 +185,11 @@ impl SharedState {
                 .request_l1("eth_getLogs", [&filter])
                 .await
                 .expect("eth_getLogs");
+            // TODO: ugly hack to fix geth inconstency issues
+            if logs.is_empty() {
+                // don't update latest block
+                return;
+            }
 
             for log in logs {
                 let topic = log.topics[0];
@@ -808,6 +813,11 @@ impl SharedState {
                 .request_l2("eth_getLogs", [&filter])
                 .await
                 .expect("eth_getLogs");
+            // TODO: ugly hack to fix geth inconstency issues
+            if logs.is_empty() {
+                // don't update latest block
+                return;
+            }
 
             for log in logs {
                 let message_id = H256::from_slice(log.data.as_ref());

--- a/coordinator/src/shared_state.rs
+++ b/coordinator/src/shared_state.rs
@@ -165,6 +165,7 @@ impl SharedState {
             .request_l1("eth_blockNumber", ())
             .await
             .expect("eth_blockNumber");
+        let mut last_to_block: U64 = U64::zero();
         let mut from: U64 = self.rw.lock().await.l1_last_sync_block + 1;
         let mut filter = Filter::new()
             .address(ValueOrArray::Value(self.config.lock().await.l1_bridge))
@@ -187,9 +188,10 @@ impl SharedState {
                 .expect("eth_getLogs");
             // TODO: ugly hack to fix geth inconstency issues
             if logs.is_empty() {
-                // don't update latest block
-                return;
+                break;
             }
+            // otherwise update
+            last_to_block = to;
 
             for log in logs {
                 let topic = log.topics[0];
@@ -260,7 +262,9 @@ impl SharedState {
             from = to + 1u64;
         }
 
-        self.rw.lock().await.l1_last_sync_block = latest_block;
+        if last_to_block != U64::zero() {
+            self.rw.lock().await.l1_last_sync_block = last_to_block;
+        }
         self.sync_l2().await;
     }
 
@@ -797,6 +801,7 @@ impl SharedState {
             .request_l2("eth_blockNumber", ())
             .await
             .expect("eth_blockNumber");
+        let mut last_to_block: U64 = U64::zero();
         let mut from: U64 = self.rw.lock().await.l2_last_sync_block + 1;
         let mut filter = Filter::new()
             .address(ValueOrArray::Value(self.ro.l2_message_deliverer_addr))
@@ -815,9 +820,10 @@ impl SharedState {
                 .expect("eth_getLogs");
             // TODO: ugly hack to fix geth inconstency issues
             if logs.is_empty() {
-                // don't update latest block
-                return;
+                break;
             }
+            // otherwise update
+            last_to_block = to;
 
             for log in logs {
                 let message_id = H256::from_slice(log.data.as_ref());
@@ -827,9 +833,11 @@ impl SharedState {
             from = to + 1u64;
         }
 
-        let mut rw = self.rw.lock().await;
-        rw.l2_last_sync_block = latest_block;
-        rw.l2_delivered_messages.extend_from_slice(&executed_msgs);
+        if last_to_block != U64::zero() {
+            let mut rw = self.rw.lock().await;
+            rw.l2_last_sync_block = last_to_block;
+            rw.l2_delivered_messages.extend_from_slice(&executed_msgs);
+        }
     }
 
     /// keeps track of L2 > L1 message events

--- a/coordinator/src/shared_state.rs
+++ b/coordinator/src/shared_state.rs
@@ -187,11 +187,9 @@ impl SharedState {
                 .await
                 .expect("eth_getLogs");
             // TODO: ugly hack to fix geth inconstency issues
-            if logs.is_empty() {
-                break;
+            if !logs.is_empty() {
+                last_to_block = to;
             }
-            // otherwise update
-            last_to_block = to;
 
             for log in logs {
                 let topic = log.topics[0];
@@ -819,11 +817,9 @@ impl SharedState {
                 .await
                 .expect("eth_getLogs");
             // TODO: ugly hack to fix geth inconstency issues
-            if logs.is_empty() {
-                break;
+            if !logs.is_empty() {
+                last_to_block = to;
             }
-            // otherwise update
-            last_to_block = to;
 
             for log in logs {
                 let message_id = H256::from_slice(log.data.as_ref());


### PR DESCRIPTION
Fix ugly race conditions in geth that works like this:
1. coordinator checks latest block number on L1, it increased. Call it LATEST
2. coordinator fetches logs from..LATEST, no results are returned (no error)
3. missed bridge events

The temporary solution is still query all blocks and only track the latest block with logs and otherwise queries all blocks again until a new block which returns events for the bridge are found.
Normally geth should throw a error like `{"jsonrpc":"2.0","id":0,"error":{"code":-32000,"message":"no trusted canonical hash trie"}}` or similiar if the block is unknown or not yet completely 'processed'.

Note: This also helps if the upstream rpc is a distributed out-of-sync endpoint too, but has nothing to do with this particular race condition.