### PR TITLE
remove precomputed params

### DIFF
--- a/.github/workflows/autogen.yml
+++ b/.github/workflows/autogen.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: EVM & Aggregation circuit verifier
         run: |
-          docker compose run --use-aliases --no-TTY --rm --entrypoint bash dev -c './scripts/autogen.sh autogen_verifier_'
+          docker compose run --use-aliases --no-TTY --rm --entrypoint bash dev -c './scripts/autogen.sh autogen_verifier_pi autogen_verifier_dummy'
 
       - name: Patch genesis templates
         run: docker run --rm -v $(pwd):/host -w /host node:lts-alpine scripts/patch_genesis.mjs

--- a/.github/workflows/autogen.yml
+++ b/.github/workflows/autogen.yml
@@ -61,6 +61,10 @@ jobs:
         run: |
           docker compose run --use-aliases --no-TTY --rm --entrypoint bash dev -c './scripts/autogen.sh autogen_verifier_pi autogen_verifier_dummy'
 
+      - name: Super circuit EVM verifier
+        run: |
+          docker compose run --use-aliases --no-TTY --rm --entrypoint bash dev -c 'ONLY_EVM=1 ./scripts/autogen.sh autogen_verifier_super'
+
       - name: Patch genesis templates
         run: docker run --rm -v $(pwd):/host -w /host node:lts-alpine scripts/patch_genesis.mjs
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,7 @@ checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 [[package]]
 name = "bus-mapping"
 version = "0.1.0"
-source = "git+https://github.com/pinkiebell/zkevm-circuits.git?rev=6bc581922807485cd9e89b4308fc08d679e5b6c2#6bc581922807485cd9e89b4308fc08d679e5b6c2"
+source = "git+https://github.com/pinkiebell/zkevm-circuits.git?rev=2b11346b88403f21186a2f8db6d6cb563e39847f#2b11346b88403f21186a2f8db6d6cb563e39847f"
 dependencies = [
  "eth-types",
  "ethers-core",
@@ -898,7 +898,7 @@ dependencies = [
 [[package]]
 name = "eth-types"
 version = "0.1.0"
-source = "git+https://github.com/pinkiebell/zkevm-circuits.git?rev=6bc581922807485cd9e89b4308fc08d679e5b6c2#6bc581922807485cd9e89b4308fc08d679e5b6c2"
+source = "git+https://github.com/pinkiebell/zkevm-circuits.git?rev=2b11346b88403f21186a2f8db6d6cb563e39847f#2b11346b88403f21186a2f8db6d6cb563e39847f"
 dependencies = [
  "ethers-core",
  "ethers-signers",
@@ -1052,7 +1052,7 @@ dependencies = [
 [[package]]
 name = "external-tracer"
 version = "0.1.0"
-source = "git+https://github.com/pinkiebell/zkevm-circuits.git?rev=6bc581922807485cd9e89b4308fc08d679e5b6c2#6bc581922807485cd9e89b4308fc08d679e5b6c2"
+source = "git+https://github.com/pinkiebell/zkevm-circuits.git?rev=2b11346b88403f21186a2f8db6d6cb563e39847f#2b11346b88403f21186a2f8db6d6cb563e39847f"
 dependencies = [
  "eth-types",
  "geth-utils",
@@ -1242,7 +1242,7 @@ dependencies = [
 [[package]]
 name = "gadgets"
 version = "0.1.0"
-source = "git+https://github.com/pinkiebell/zkevm-circuits.git?rev=6bc581922807485cd9e89b4308fc08d679e5b6c2#6bc581922807485cd9e89b4308fc08d679e5b6c2"
+source = "git+https://github.com/pinkiebell/zkevm-circuits.git?rev=2b11346b88403f21186a2f8db6d6cb563e39847f#2b11346b88403f21186a2f8db6d6cb563e39847f"
 dependencies = [
  "digest 0.7.6",
  "eth-types",
@@ -1282,7 +1282,7 @@ dependencies = [
 [[package]]
 name = "geth-utils"
 version = "0.1.0"
-source = "git+https://github.com/pinkiebell/zkevm-circuits.git?rev=6bc581922807485cd9e89b4308fc08d679e5b6c2#6bc581922807485cd9e89b4308fc08d679e5b6c2"
+source = "git+https://github.com/pinkiebell/zkevm-circuits.git?rev=2b11346b88403f21186a2f8db6d6cb563e39847f#2b11346b88403f21186a2f8db6d6cb563e39847f"
 dependencies = [
  "gobuild",
 ]
@@ -1735,7 +1735,7 @@ checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 [[package]]
 name = "keccak256"
 version = "0.1.0"
-source = "git+https://github.com/pinkiebell/zkevm-circuits.git?rev=6bc581922807485cd9e89b4308fc08d679e5b6c2#6bc581922807485cd9e89b4308fc08d679e5b6c2"
+source = "git+https://github.com/pinkiebell/zkevm-circuits.git?rev=2b11346b88403f21186a2f8db6d6cb563e39847f#2b11346b88403f21186a2f8db6d6cb563e39847f"
 dependencies = [
  "eth-types",
  "halo2_proofs 0.1.0",
@@ -1900,7 +1900,7 @@ dependencies = [
 [[package]]
 name = "mock"
 version = "0.1.0"
-source = "git+https://github.com/pinkiebell/zkevm-circuits.git?rev=6bc581922807485cd9e89b4308fc08d679e5b6c2#6bc581922807485cd9e89b4308fc08d679e5b6c2"
+source = "git+https://github.com/pinkiebell/zkevm-circuits.git?rev=2b11346b88403f21186a2f8db6d6cb563e39847f#2b11346b88403f21186a2f8db6d6cb563e39847f"
 dependencies = [
  "eth-types",
  "ethers-core",
@@ -3625,7 +3625,7 @@ checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 [[package]]
 name = "zkevm-circuits"
 version = "0.1.0"
-source = "git+https://github.com/pinkiebell/zkevm-circuits.git?rev=6bc581922807485cd9e89b4308fc08d679e5b6c2#6bc581922807485cd9e89b4308fc08d679e5b6c2"
+source = "git+https://github.com/pinkiebell/zkevm-circuits.git?rev=2b11346b88403f21186a2f8db6d6cb563e39847f#2b11346b88403f21186a2f8db6d6cb563e39847f"
 dependencies = [
  "array-init",
  "bus-mapping",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-eth-types = { git = "https://github.com/pinkiebell/zkevm-circuits.git", rev = "6bc581922807485cd9e89b4308fc08d679e5b6c2" }
+eth-types = { git = "https://github.com/pinkiebell/zkevm-circuits.git", rev = "2b11346b88403f21186a2f8db6d6cb563e39847f" }
 hyper = { version = "0.14.16", features = ["server"] }
 log = "0.4.14"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/common/src/prover.rs
+++ b/common/src/prover.rs
@@ -52,8 +52,9 @@ pub struct ProofRequestOptions {
     pub rpc: String,
     /// retry proof computation if error
     pub retry: bool,
-    /// parameter file to use
-    pub param: String,
+    /// Parameters file or directory to use.
+    /// Otherwise generates them on the fly.
+    pub param: Option<String>,
     /// Only use MockProver if true.
     #[serde(default = "default_bool")]
     pub mock: bool,

--- a/coordinator/src/config.rs
+++ b/coordinator/src/config.rs
@@ -59,7 +59,8 @@ pub struct Config {
 
     #[clap(long, env = "COORDINATOR_PARAMS_PATH")]
     /// Parameters file or directory to use for the prover requests.
-    pub params_path: String,
+    /// Otherwise generates them on the fly.
+    pub params_path: Option<String>,
 
     #[clap(long, env = "COORDINATOR_CIRCUIT_NAME")]
     /// The name of the circuit to use in proof requests.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,7 +129,6 @@ services:
       - COORDINATOR_PROVER_RPCD_URL=http://prover-rpcd:8545
       - COORDINATOR_DUMMY_PROVER=${COORDINATOR_DUMMY_PROVER:-true}
       - COORDINATOR_ENABLE_FAUCET=true
-      - COORDINATOR_PARAMS_PATH=${PARAMS_PATH:-/testnet/}
       - COORDINATOR_CIRCUIT_NAME=super
       - COORDINATOR_UNSAFE_RPC=${COORDINATOR_UNSAFE_RPC:-false}
 
@@ -189,9 +188,6 @@ services:
       - COORDINATOR_L1_PRIV=$MINER_PRIV_KEY
       - COORDINATOR_DUMMY_PROVER=${COORDINATOR_DUMMY_PROVER:-true}
       - COORDINATOR_ENABLE_FAUCET=true
-      # enable automatic parameter selection based on block gas
-      - COORDINATOR_PARAMS_PATH=${PARAMS_PATH:-/testnet/}
-      - PROVERD_PARAMS_PATH=${PARAMS_PATH:-/testnet/}
       # useful env vars if running the proverd inside the dev image
       - PROVERD_LOOKUP=dev:8001
       - COORDINATOR_PROVER_RPCD_URL=http://dev:8001

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -12,14 +12,11 @@ RUN \
       mv solc/solc /solc && \
       rm -rf $(pwd)
 
-FROM ghcr.io/privacy-scaling-explorations/zkevm-chain/params@sha256:f5936391e1d67515f6625c9e49525adc4cd6ebd9caecedc5ce0fad5d7c4b1d65 AS params
-
 # developer image
 # Should be alpine like the production images but fails due to
 # linkage bug(segfaults of test binaries w/ linked golang code) in rust.
 # Use debian until this is resolved.
 FROM debian:bookworm-slim
-COPY --from=params /testnet /testnet
 COPY --from=solc /solc /usr/bin/solc
 ENV CARGO_TARGET_DIR=/target
 ENV CARGO_HOME=/usr/local/cargo

--- a/docker/prover/Dockerfile
+++ b/docker/prover/Dockerfile
@@ -24,8 +24,6 @@ COPY . .
 RUN cargo build --locked --bin prover_rpcd --release --target-dir /target --target $(cat /tmp/target) && \
       mv /target/*-unknown-linux-musl/release/prover_rpcd / && rm -rf /target
 
-FROM ghcr.io/privacy-scaling-explorations/zkevm-chain/params@sha256:f5936391e1d67515f6625c9e49525adc4cd6ebd9caecedc5ce0fad5d7c4b1d65 AS params
 FROM alpine@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1acc53015037c
 ENTRYPOINT ["/prover_rpcd"]
-COPY --from=params /testnet /testnet
 COPY --from=builder /prover_rpcd /

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -6,9 +6,9 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_10_22" }
-bus-mapping = { git = "https://github.com/pinkiebell/zkevm-circuits.git", rev = "6bc581922807485cd9e89b4308fc08d679e5b6c2" }
-eth-types = { git = "https://github.com/pinkiebell/zkevm-circuits.git", rev = "6bc581922807485cd9e89b4308fc08d679e5b6c2" }
-zkevm-circuits = { git = "https://github.com/pinkiebell/zkevm-circuits.git", rev = "6bc581922807485cd9e89b4308fc08d679e5b6c2" }
+bus-mapping = { git = "https://github.com/pinkiebell/zkevm-circuits.git", rev = "2b11346b88403f21186a2f8db6d6cb563e39847f" }
+eth-types = { git = "https://github.com/pinkiebell/zkevm-circuits.git", rev = "2b11346b88403f21186a2f8db6d6cb563e39847f" }
+zkevm-circuits = { git = "https://github.com/pinkiebell/zkevm-circuits.git", rev = "2b11346b88403f21186a2f8db6d6cb563e39847f" }
 plonk_verifier = { git = "https://github.com/privacy-scaling-explorations/plonk-verifier.git", rev = "ba167b73ca09d77ab08958d4a4b4e0433222e4db" }
 env_logger = "0.9.0"
 ethers-providers = "0.17.0"
@@ -25,7 +25,7 @@ itertools = "0.10.3"
 clap = { version = "4.0.14", features = ["derive", "env"] }
 
 # autogen
-mock = { git = "https://github.com/pinkiebell/zkevm-circuits.git", rev = "6bc581922807485cd9e89b4308fc08d679e5b6c2", optional = true }
+mock = { git = "https://github.com/pinkiebell/zkevm-circuits.git", rev = "2b11346b88403f21186a2f8db6d6cb563e39847f", optional = true }
 ethers-signers = { version = "0.17.0", optional = true }
 
 [features]

--- a/prover/src/bin/prover_cmd.rs
+++ b/prover/src/bin/prover_cmd.rs
@@ -31,7 +31,7 @@ async fn main() {
         block: block_num,
         rpc: rpc_url,
         retry: false,
-        param: params_path,
+        param: Some(params_path),
         mock: false,
         aggregate: false,
         ..Default::default()

--- a/prover/src/circuit_witness.rs
+++ b/prover/src/circuit_witness.rs
@@ -100,6 +100,7 @@ impl CircuitWitness {
     pub fn evm_witness(&self) -> (zkevm_circuits::witness::Block<Fr>, Vec<Vec<u8>>) {
         let mut block = evm_circuit::witness::block_convert(&self.block, &self.code_db);
         block.evm_circuit_pad_to = self.circuit_config.pad_to;
+        block.exp_circuit_pad_to = self.circuit_config.pad_to;
         let keccak_inputs = self.keccak_inputs.clone();
 
         (block, keccak_inputs)

--- a/prover/src/server.rs
+++ b/prover/src/server.rs
@@ -220,7 +220,6 @@ async fn handle_method(
 
             if options.cache {
                 rw_state.pk_cache.clear();
-                rw_state.params_cache.clear();
             }
             if options.pending {
                 rw_state.tasks.retain(|e| e.result.is_some());

--- a/prover/src/shared_state.rs
+++ b/prover/src/shared_state.rs
@@ -43,10 +43,7 @@ fn get_param_path(path: &String, k: usize) -> String {
     }
 }
 
-async fn get_or_gen_param(
-    task_options: &ProofRequestOptions,
-    k: usize,
-) -> (Arc<ProverParams>, String) {
+fn get_or_gen_param(task_options: &ProofRequestOptions, k: usize) -> (Arc<ProverParams>, String) {
     match &task_options.param {
         Some(v) => {
             let path = get_param_path(v, k);
@@ -75,7 +72,7 @@ macro_rules! gen_proof {
 
         log::info!("Using circuit parameters: {:#?}", CIRCUIT_CONFIG);
 
-        let (param, param_path) = get_or_gen_param(&task_options, CIRCUIT_CONFIG.min_k).await;
+        let (param, param_path) = get_or_gen_param(&task_options, CIRCUIT_CONFIG.min_k);
         let mut circuit_proof = ProofResult::default();
         circuit_proof.label = format!(
             "{}-{}",
@@ -154,7 +151,7 @@ macro_rules! gen_proof {
                 let snark = Snark::new(protocol, circuit_instance, proof);
 
                 let (agg_params, agg_param_path) =
-                    get_or_gen_param(&task_options, CIRCUIT_CONFIG.min_k_aggregation).await;
+                    get_or_gen_param(&task_options, CIRCUIT_CONFIG.min_k_aggregation);
                 aggregation_proof.k = agg_params.k() as u8;
                 let agg_circuit =
                     AggregationCircuit::new(agg_params.as_ref(), [snark], fixed_rng());

--- a/prover/src/shared_state.rs
+++ b/prover/src/shared_state.rs
@@ -33,13 +33,35 @@ use tokio::sync::Mutex;
 use zkevm_common::json_rpc::jsonrpc_request_client;
 use zkevm_common::prover::*;
 
-fn get_param_path(task_options: &ProofRequestOptions, k: usize) -> String {
+fn get_param_path(path: &String, k: usize) -> String {
     // try to automatically choose a file if the path ends with a `/`.
-    match task_options.param.ends_with('/') {
+    match path.ends_with('/') {
         true => {
-            format!("{}{}.bin", task_options.param, k)
+            format!("{}{}.bin", path, k)
         }
-        false => task_options.param.clone(),
+        false => path.clone(),
+    }
+}
+
+async fn get_or_gen_param(
+    task_options: &ProofRequestOptions,
+    k: usize,
+) -> (Arc<ProverParams>, String) {
+    match &task_options.param {
+        Some(v) => {
+            let path = get_param_path(v, k);
+            let file = File::open(&path).expect("couldn't open params");
+            let params = Arc::new(
+                ProverParams::read(&mut std::io::BufReader::new(file))
+                    .expect("Failed to read params"),
+            );
+
+            (params, path)
+        }
+        None => {
+            let param = Arc::new(ProverParams::setup(k as u32, fixed_rng()));
+            (param, format!("{}", k))
+        }
     }
 }
 
@@ -47,19 +69,13 @@ macro_rules! gen_proof {
     ($shared_state:expr, $task_options:expr, $witness:expr, $CIRCUIT:ident) => {{
         let witness = $witness;
         // uncomment for testing purposes
-        // Note: evm verifier doesn't work yet with different inputs
         //let witness = CircuitWitness::dummy(CIRCUIT_CONFIG.block_gas_limit).unwrap();
         let task_options = $task_options;
         let shared_state = $shared_state;
 
         log::info!("Using circuit parameters: {:#?}", CIRCUIT_CONFIG);
 
-        // lazily load the file and cache it.
-        // Note: we are not validating it for `min_k`,
-        // this error will eventually bubble up later.
-        let param_path = get_param_path(&task_options, CIRCUIT_CONFIG.min_k);
-        let param = shared_state.load_param(&param_path).await;
-
+        let (param, param_path) = get_or_gen_param(&task_options, CIRCUIT_CONFIG.min_k).await;
         let mut circuit_proof = ProofResult::default();
         circuit_proof.label = format!(
             "{}-{}",
@@ -100,7 +116,7 @@ macro_rules! gen_proof {
                     &task_options.circuit, &param_path, &CIRCUIT_CONFIG
                 );
                 shared_state
-                    .gen_pk(&cache_key, &param_path, &circuit)
+                    .gen_pk(&cache_key, &param, &circuit)
                     .await
                     .map_err(|e| e.to_string())?
             };
@@ -137,11 +153,9 @@ macro_rules! gen_proof {
                 );
                 let snark = Snark::new(protocol, circuit_instance, proof);
 
-                let agg_param_path =
-                    get_param_path(&task_options, CIRCUIT_CONFIG.min_k_aggregation);
-                let agg_params = shared_state.load_param(&agg_param_path).await;
+                let (agg_params, agg_param_path) =
+                    get_or_gen_param(&task_options, CIRCUIT_CONFIG.min_k_aggregation).await;
                 aggregation_proof.k = agg_params.k() as u8;
-
                 let agg_circuit =
                     AggregationCircuit::new(agg_params.as_ref(), [snark], fixed_rng());
                 let agg_pk = {
@@ -150,7 +164,7 @@ macro_rules! gen_proof {
                         &task_options.circuit, &agg_param_path, &CIRCUIT_CONFIG
                     );
                     shared_state
-                        .gen_pk(&cache_key, &agg_param_path, &agg_circuit)
+                        .gen_pk(&cache_key, &agg_params, &agg_circuit)
                         .await
                         .map_err(|e| e.to_string())?
                 };
@@ -211,7 +225,6 @@ pub struct RoState {
 
 pub struct RwState {
     pub tasks: Vec<ProofRequest>,
-    pub params_cache: HashMap<String, Arc<ProverParams>>,
     pub pk_cache: HashMap<String, Arc<ProverKey>>,
     /// The current active task this instance wants to obtain or is working on.
     pub pending: Option<ProofRequestOptions>,
@@ -234,7 +247,6 @@ impl SharedState {
             },
             rw: Arc::new(Mutex::new(RwState {
                 tasks: Vec::new(),
-                params_cache: HashMap::new(),
                 pk_cache: HashMap::new(),
                 pending: None,
                 obtained: false,
@@ -498,30 +510,6 @@ impl SharedState {
         Ok(true)
     }
 
-    async fn load_param(&self, params_path: &str) -> Arc<ProverParams> {
-        let mut rw = self.rw.lock().await;
-
-        if !rw.params_cache.contains_key(params_path) {
-            // drop, potentially long running
-            drop(rw);
-
-            // load polynomial commitment parameters
-            let params_fs = File::open(params_path).expect("couldn't open params");
-            let params: Arc<ProverParams> = Arc::new(
-                ProverParams::read(&mut std::io::BufReader::new(params_fs))
-                    .expect("Failed to read params"),
-            );
-
-            // acquire lock and update
-            rw = self.rw.lock().await;
-            rw.params_cache.insert(params_path.to_string(), params);
-
-            log::info!("params: initialized {}", params_path);
-        }
-
-        rw.params_cache.get(params_path).unwrap().clone()
-    }
-
     // TODO: can this be pre-generated to a file?
     // related
     // https://github.com/zcash/halo2/issues/443
@@ -530,7 +518,7 @@ impl SharedState {
     async fn gen_pk<C: Circuit<Fr>>(
         &self,
         cache_key: &str,
-        params_path: &str,
+        param: &Arc<ProverParams>,
         circuit: &C,
     ) -> Result<Arc<ProverKey>, Box<dyn std::error::Error>> {
         let mut rw = self.rw.lock().await;
@@ -538,7 +526,6 @@ impl SharedState {
             // drop, potentially long running
             drop(rw);
 
-            let param = self.load_param(params_path).await;
             let vk = keygen_vk(param.as_ref(), circuit)?;
             let pk = keygen_pk(param.as_ref(), vk, circuit)?;
             let pk = Arc::new(pk);

--- a/prover/src/super_circuit.rs
+++ b/prover/src/super_circuit.rs
@@ -35,7 +35,7 @@ pub fn gen_circuit<
     let aux_generator = <Secp256k1Affine as CurveAffine>::CurveExt::random(&mut rng).to_affine();
     let tx_circuit = TxCircuit::new(aux_generator, chain_id.as_u64(), witness.txs());
     let circuit = SuperCircuit::<Fr, MAX_TXS, MAX_CALLDATA, MAX_RWS> {
-        block,
+        block: Some(block),
         fixed_table_tags: FixedTableTag::iter().collect(),
         tx_circuit,
         keccak_inputs,

--- a/prover/tests/proverd.rs
+++ b/prover/tests/proverd.rs
@@ -27,7 +27,6 @@ async fn proverd_simple_signaling() {
     let proof_a = ProofRequestOptions {
         circuit: "super".to_string(),
         block: 1,
-        param: "/none".to_string(),
         retry: false,
         rpc: "http://localhost:1111".to_string(),
         ..Default::default()
@@ -35,7 +34,6 @@ async fn proverd_simple_signaling() {
     let proof_b = ProofRequestOptions {
         circuit: "super".to_string(),
         block: 2,
-        param: "/none".to_string(),
         retry: false,
         rpc: "http://localhost:1111".to_string(),
         ..Default::default()


### PR DESCRIPTION
- remove precomputed params
- add support for generating params on the fly
- remove caching of the params file 
- upgrade zkevm-circuits
- set block.exp_circuit_pad_to

Fixes: #92, #90 using new generated parameters seems to fix the circuit issue