### PR TITLE
Use same mock randomness for all sub-circuits

### DIFF
--- a/prover/src/super_circuit.rs
+++ b/prover/src/super_circuit.rs
@@ -22,11 +22,10 @@ pub fn gen_circuit<
     witness: &CircuitWitness,
     mut rng: RNG,
 ) -> Result<SuperCircuit<Fr, MAX_TXS, MAX_CALLDATA, MAX_RWS>, String> {
-    let (mut block, keccak_inputs) = witness.evm_witness();
-    block.randomness = Fr::random(&mut rng);
+    let (block, keccak_inputs) = witness.evm_witness();
 
     let pi_circuit = PiCircuit::<Fr, MAX_TXS, MAX_CALLDATA> {
-        randomness: Fr::random(&mut rng),
+        randomness: block.randomness,
         rand_rpi: Fr::random(&mut rng),
         public_data: witness.public_data(),
     };


### PR DESCRIPTION
Since currently `SuperCircuit` is configured to use a [fixed mock randomness](https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/d3a53abb21fe844fcadcc27750daea1fdc1bb968/zkevm-circuits/src/super_circuit.rs#L182-L184).

Also even block is empty, we still need to let `CircuitInputBuilder` to generate witness for `EndBlock` steps.