### PR TITLE
fix: add a cargo config for macOS compatible

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.'cfg(target_os="macos")']
+rustflags = ["-C", "link-args=-framework CoreFoundation -framework Security"]


### PR DESCRIPTION
There will be `Undefined symbols for architecture` error while building on MacOS. Add a cargo config to avoid this. 

Ref: https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/main/.cargo/config.toml