### PR TITLE
Add docker memory limits to dev and prover container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,9 @@ services:
       - PROVERD_LOOKUP=prover-rpcd:8545
     deploy:
       replicas: 1
+      resources:
+        limits:
+          memory: 3000G
 
   coverage-l1:
     profiles:
@@ -195,6 +198,10 @@ services:
     command: '-'
     tty: true
     init: true
+    deploy:
+      resources:
+        limits:
+          memory: 3000G
 
   web:
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,7 +138,7 @@ services:
       replicas: 1
       resources:
         limits:
-          memory: 3000G
+          memory: 2500G
 
   coverage-l1:
     profiles:
@@ -201,7 +201,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 3000G
+          memory: 2500G
 
   web:
     depends_on:


### PR DESCRIPTION
2500 gigabytes allows for more headroom given the large super circuit
fixes #123 